### PR TITLE
fix: update HEX codes for tick and x character in switches

### DIFF
--- a/Angular4_CLI_Full_Project/src/app/views/components/switches.component.html
+++ b/Angular4_CLI_Full_Project/src/app/views/components/switches.component.html
@@ -593,37 +593,37 @@
         <div class="card-body">
           <label class="switch switch-icon switch-primary">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-secondary">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-success">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-warning">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-info">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-danger">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
         </div>
@@ -638,37 +638,37 @@
         <div class="card-body">
           <label class="switch switch-icon switch-pill switch-primary">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-secondary">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-success">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-warning">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-info">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-danger">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
         </div>
@@ -683,37 +683,37 @@
         <div class="card-body">
           <label class="switch switch-icon switch-primary-outline">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-secondary-outline">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-success-outline">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-warning-outline">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-info-outline">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-danger-outline">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
         </div>
@@ -728,37 +728,37 @@
         <div class="card-body">
           <label class="switch switch-icon switch-pill switch-primary-outline">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-secondary-outline">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-success-outline">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-warning-outline">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-info-outline">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-danger-outline">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
         </div>
@@ -773,37 +773,37 @@
         <div class="card-body">
           <label class="switch switch-icon switch-primary-outline-alt">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-secondary-outline-alt">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-success-outline-alt">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-warning-outline-alt">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-info-outline-alt">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-danger-outline-alt">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
         </div>
@@ -818,37 +818,37 @@
         <div class="card-body">
           <label class="switch switch-icon switch-pill switch-primary-outline-alt">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-secondary-outline-alt">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-success-outline-alt">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-warning-outline-alt">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-info-outline-alt">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
           &nbsp;&nbsp;&nbsp;
           <label class="switch switch-icon switch-pill switch-danger-outline-alt">
             <input type="checkbox" class="switch-input" checked>
-            <span class="switch-label" data-on="&#xf00c;" data-off="&#xf00d;"></span>
+            <span class="switch-label" data-on="&#x2714;" data-off="&#x2716;"></span>
             <span class="switch-handle"></span>
           </label>
         </div>


### PR DESCRIPTION
Somehow the font-awesome hex code don't get converted to the character when used in the pages. This patch changes them to codes that do work.