### PR TITLE
Updates Angular compiler to preserve whitespace

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,5 +8,7 @@ if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
+platformBrowserDynamic().bootstrapModule(AppModule, {
+    preserveWhitespaces: true
+})
   .catch(err => console.log(err));


### PR DESCRIPTION
Angular now defaults to removing all whitespace (including newlines) in templates, but CoreUI currently relies on newlines to be represented as whitespace between buttons and headings.